### PR TITLE
add role timers back according to the draft

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
@@ -3,6 +3,12 @@
   name: job-name-qm
   description: job-description-qm
   playTimeTracker: JobQuartermaster
+  requirements:
+  - !type:DepartmentTimeRequirement
+    department: Cargo
+    time: 18000 #5 hrs
+  - !type:OverallPlaytimeRequirement
+    time: 36000 #10 hrs
   weight: 10
   startingGear: QuartermasterGear
   icon: "JobIconQuarterMaster"

--- a/Resources/Prototypes/Roles/Jobs/Cargo/salvage_specialist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/salvage_specialist.yml
@@ -3,6 +3,9 @@
   name: job-name-salvagespec
   description: job-description-salvagespec
   playTimeTracker: JobSalvageSpecialist
+  requirements:
+  - !type:OverallPlaytimeRequirement
+    time: 7200 #2 hrs
   icon: "JobIconShaftMiner"
   startingGear: SalvageSpecialistGear
   supervisors: job-supervisors-qm

--- a/Resources/Prototypes/Roles/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/captain.yml
@@ -3,6 +3,12 @@
   name: job-name-captain
   description: job-description-captain
   playTimeTracker: JobCaptain
+  requirements:
+  - !type:DepartmentTimeRequirement
+    department: Command
+    time: 36000 #10 hrs
+  - !type:OverallPlaytimeRequirement
+    time: 72000 #20 hrs
   weight: 20
   startingGear: CaptainGear
   icon: "JobIconCaptain"

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -3,6 +3,9 @@
   name: job-name-hop
   description: job-description-hop
   playTimeTracker: JobHeadOfPersonnel
+  requirements:
+  - !type:OverallPlaytimeRequirement
+    time: 36000 #10 hrs
   weight: 20
   startingGear: HoPGear
   icon: "JobIconHeadOfPersonnel"

--- a/Resources/Prototypes/Roles/Jobs/Engineering/atmospheric_technician.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/atmospheric_technician.yml
@@ -3,6 +3,9 @@
   name: job-name-atmostech
   description: job-description-atmostech
   playTimeTracker: JobAtmosphericTechnician
+  requirements:
+  - !type:OverallPlaytimeRequirement
+    time: 7200 #2 hrs
   startingGear: AtmosphericTechnicianGear
   icon: "JobIconAtmosphericTechnician"
   supervisors: job-supervisors-ce

--- a/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
@@ -3,6 +3,12 @@
   name: job-name-ce
   description: job-description-ce
   playTimeTracker: JobChiefEngineer
+  requirements:
+  - !type:DepartmentTimeRequirement
+    department: Engineering
+    time: 32400 #9 hrs
+  - !type:OverallPlaytimeRequirement
+    time: 36000 #10 hrs
   weight: 10
   startingGear: ChiefEngineerGear
   icon: "JobIconChiefEngineer"

--- a/Resources/Prototypes/Roles/Jobs/Engineering/station_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/station_engineer.yml
@@ -3,6 +3,9 @@
   name: job-name-engineer
   description: job-description-engineer
   playTimeTracker: JobStationEngineer
+  requirements:
+  - !type:OverallPlaytimeRequirement
+    time: 5400 #1.5 hrs
   startingGear: StationEngineerGear
   icon: "JobIconStationEngineer"
   supervisors: job-supervisors-ce

--- a/Resources/Prototypes/Roles/Jobs/Engineering/technical_assistant.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/technical_assistant.yml
@@ -3,6 +3,9 @@
   name: job-name-technical-assistant
   description: job-description-technical-assistant
   playTimeTracker: JobTechnicalAssistant
+  requirements:
+  - !type:OverallPlaytimeRequirement
+    time: 3600 #1 hrs, often picked by raiders
   startingGear: TechnicalAssistantGear
   icon: "JobIconTechnicalAssistant"
   supervisors: job-supervisors-engineering

--- a/Resources/Prototypes/Roles/Jobs/Medical/chemist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chemist.yml
@@ -3,6 +3,9 @@
   name: job-name-chemist
   description: job-description-chemist
   playTimeTracker: JobChemist
+  requirements:
+  - !type:OverallPlaytimeRequirement
+    time: 5400 #1.5 hrs
   startingGear: ChemistGear
   icon: "JobIconChemist"
   supervisors: job-supervisors-cmo

--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -5,6 +5,12 @@
   name: job-name-cmo
   description: job-description-cmo
   playTimeTracker: JobChiefMedicalOfficer
+  requirements:
+  - !type:DepartmentTimeRequirement
+    department: Medical
+    time: 18000 #5 hrs
+  - !type:OverallPlaytimeRequirement
+    time: 36000 #10 hrs
   weight: 10
   startingGear: CMOGear
   icon: "JobIconChiefMedicalOfficer"

--- a/Resources/Prototypes/Roles/Jobs/Medical/medical_doctor.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/medical_doctor.yml
@@ -3,6 +3,9 @@
   name: job-name-doctor
   description: job-description-doctor
   playTimeTracker: JobMedicalDoctor
+  requirements:
+  - !type:OverallPlaytimeRequirement
+    time: 3600 #1 hrs
   startingGear: DoctorGear
   icon: "JobIconMedicalDoctor"
   supervisors: job-supervisors-cmo

--- a/Resources/Prototypes/Roles/Jobs/Medical/paramedic.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/paramedic.yml
@@ -3,6 +3,9 @@
   name: job-name-paramedic
   description: job-description-paramedic
   playTimeTracker: JobParamedic
+  requirements:
+  - !type:OverallPlaytimeRequirement
+    time: 3600 #1 hrs
   startingGear: ParamedicGear
   icon: "JobIconParamedic"
   supervisors: job-supervisors-cmo

--- a/Resources/Prototypes/Roles/Jobs/Science/borg.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/borg.yml
@@ -3,6 +3,9 @@
   name: job-name-borg
   description: job-description-borg
   playTimeTracker: JobBorg
+  requirements:
+  - !type:OverallPlaytimeRequirement
+    time: 7200 #2 hrs
   canBeAntag: false
   icon: JobIconBorg
   supervisors: job-supervisors-rd

--- a/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
@@ -3,6 +3,12 @@
   name: job-name-rd
   description: job-description-rd
   playTimeTracker: JobResearchDirector
+  requirements:
+  - !type:DepartmentTimeRequirement
+    department: Science
+    time: 18000 #5 hrs
+  - !type:OverallPlaytimeRequirement
+    time: 36000 #10 hrs
   weight: 10
   startingGear: ResearchDirectorGear
   icon: "JobIconResearchDirector"

--- a/Resources/Prototypes/Roles/Jobs/Science/scientist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/scientist.yml
@@ -3,6 +3,9 @@
   name: job-name-scientist
   description: job-description-scientist
   playTimeTracker: JobScientist
+  requirements:
+  - !type:OverallPlaytimeRequirement
+    time: 3600 #1 hrs
   startingGear: ScientistGear
   icon: "JobIconScientist"
   supervisors: job-supervisors-rd

--- a/Resources/Prototypes/Roles/Jobs/Security/detective.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/detective.yml
@@ -3,6 +3,9 @@
   name: job-name-detective
   description: job-description-detective
   playTimeTracker: JobDetective
+  requirements:
+  - !type:OverallPlaytimeRequirement
+    time: 7200 #2 hrs
   startingGear: DetectiveGear
   icon: "JobIconDetective"
   supervisors: job-supervisors-hos

--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -3,6 +3,12 @@
   name: job-name-hos
   description: job-description-hos
   playTimeTracker: JobHeadOfSecurity
+  requirements:
+  - !type:DepartmentTimeRequirement
+    department: Security
+    time: 32400 #9 hrs
+  - !type:OverallPlaytimeRequirement
+    time: 36000 #10 hrs
   weight: 10
   startingGear: HoSGear
   icon: "JobIconHeadOfSecurity"

--- a/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
@@ -3,6 +3,9 @@
   name: job-name-cadet
   description: job-description-cadet
   playTimeTracker: JobSecurityCadet
+  requirements:
+  - !type:OverallPlaytimeRequirement
+    time: 3600 #1 hrs
   startingGear: SecurityCadetGear
   icon: "JobIconSecurityCadet"
   supervisors: job-supervisors-security

--- a/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
@@ -3,6 +3,9 @@
   name: job-name-security
   description: job-description-security
   playTimeTracker: JobSecurityOfficer
+  requirements:
+  - !type:OverallPlaytimeRequirement
+    time: 7200 #2 hrs
   startingGear: SecurityOfficerGear
   icon: "JobIconSecurityOfficer"
   supervisors: job-supervisors-hos

--- a/Resources/Prototypes/Roles/Jobs/Security/warden.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/warden.yml
@@ -3,6 +3,9 @@
   name: job-name-warden
   description: job-description-warden
   playTimeTracker: JobWarden
+  requirements:
+  - !type:OverallPlaytimeRequirement
+    time: 18000 #5 hrs
   startingGear: WardenGear
   icon: "JobIconWarden"
   supervisors: job-supervisors-hos


### PR DESCRIPTION
## About the PR
Role playtime requirements are back, they were adjusted to fit Axolotl

## Why / Balance
yunii asked me

## Technical details


## Media
tested it on Release build, all requirements are working
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes

**Changelog**

:cl:
- tweak: Role timers are back with playtimes adjusted for Axolotl.
